### PR TITLE
🧪 Add unit test for TerminalBuffer::backspace

### DIFF
--- a/src/terminal_buffer.rs
+++ b/src/terminal_buffer.rs
@@ -191,3 +191,40 @@ impl TerminalBuffer {
         self.cursor_x = 0;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backspace() {
+        let mut buffer = TerminalBuffer::new(10, 10);
+
+        // Test backspace at (0, 0) - should do nothing
+        buffer.backspace();
+        assert_eq!(buffer.cursor_x, 0);
+        assert_eq!(buffer.cursor_y, 0);
+
+        // Put some characters
+        buffer.put_char('A');
+        buffer.put_char('B');
+        assert_eq!(buffer.cursor_x, 2);
+        assert_eq!(buffer.cells[0][0].character, 'A');
+        assert_eq!(buffer.cells[0][1].character, 'B');
+
+        // Backspace once
+        buffer.backspace();
+        assert_eq!(buffer.cursor_x, 1);
+        assert_eq!(buffer.cells[0][1], TerminalCell::default());
+        assert_eq!(buffer.cells[0][0].character, 'A');
+
+        // Backspace again
+        buffer.backspace();
+        assert_eq!(buffer.cursor_x, 0);
+        assert_eq!(buffer.cells[0][0], TerminalCell::default());
+
+        // Backspace again at 0
+        buffer.backspace();
+        assert_eq!(buffer.cursor_x, 0);
+    }
+}

--- a/src/terminal_cell.rs
+++ b/src/terminal_cell.rs
@@ -1,6 +1,6 @@
 use eframe::egui::Color32;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TerminalCell {
     pub character: char,
     pub fg_color: Color32,


### PR DESCRIPTION
🎯 **What:** This change addresses the untested `TerminalBuffer::backspace` method.
📊 **Coverage:** The new test `test_backspace` covers:
- Backspacing from a middle position.
- Backspacing from the start of a line (position 0).
- Verifying that characters are correctly cleared and the cursor position is updated.
✨ **Result:** Improved test coverage for core terminal buffer manipulation logic, ensuring its reliability and preventing regressions.

---
*PR created automatically by Jules for task [4345043001294091353](https://jules.google.com/task/4345043001294091353) started by @BlueGeckoJP*