### PR TITLE
⚡ Optimize get_visible_lines to reduce allocation overhead

### DIFF
--- a/src/terminal_widget.rs
+++ b/src/terminal_widget.rs
@@ -35,6 +35,7 @@ pub struct TerminalWidget {
     max_scroll_lines: usize,
     scrollback_buffer: Vec<Vec<TerminalCell>>,
     new_line_mode: bool,
+    empty_line: Vec<TerminalCell>,
 }
 
 impl TerminalWidget {
@@ -61,6 +62,7 @@ impl TerminalWidget {
             max_scroll_lines: 1000,
             scrollback_buffer: Vec::new(),
             new_line_mode: true,
+            empty_line: vec![TerminalCell::default(); width],
         }
     }
 
@@ -133,10 +135,10 @@ impl TerminalWidget {
         response
     }
 
-    fn get_visible_lines(&self) -> Vec<Vec<TerminalCell>> {
+    fn get_visible_lines(&self) -> Vec<&[TerminalCell]> {
         if self.scroll_offset == 0 {
             // At the bottom, show current buffer
-            return self.buffer.cells.clone();
+            return self.buffer.cells.iter().map(|l| l.as_slice()).collect();
         }
 
         let mut visible_lines = Vec::new();
@@ -147,16 +149,16 @@ impl TerminalWidget {
             if line_index_from_bottom < self.buffer.height {
                 // This line is in the current buffer
                 let buffer_line_index = self.buffer.height - 1 - line_index_from_bottom;
-                visible_lines.push(self.buffer.cells[buffer_line_index].clone());
+                visible_lines.push(self.buffer.cells[buffer_line_index].as_slice());
             } else {
                 // This line is in the scrollback buffer
                 let scrollback_index = line_index_from_bottom - self.buffer.height;
                 if scrollback_index < self.scrollback_buffer.len() {
                     let scrollback_line_index = self.scrollback_buffer.len() - 1 - scrollback_index;
-                    visible_lines.push(self.scrollback_buffer[scrollback_line_index].clone());
+                    visible_lines.push(self.scrollback_buffer[scrollback_line_index].as_slice());
                 } else {
                     // Empty line if we're beyond available history
-                    visible_lines.push(vec![TerminalCell::default(); self.buffer.width]);
+                    visible_lines.push(self.empty_line.as_slice());
                 }
             }
         }
@@ -173,6 +175,8 @@ impl TerminalWidget {
                 line.truncate(new_width);
             }
         }
+
+        self.empty_line.resize(new_width, TerminalCell::default());
     }
 
     pub fn process_output(&mut self, ctx: &egui::Context, data: &[u8]) {


### PR DESCRIPTION
💡 **What:** Refactored `get_visible_lines` in `TerminalWidget` to return a `Vec` of slices (`&[TerminalCell]`) instead of a `Vec` of cloned vectors. Added a pre-allocated `empty_line` buffer to `TerminalWidget` to provide a consistent reference for lines beyond the scrollback history.

🎯 **Why:** `get_visible_lines` is called on every frame (60fps). The previous implementation cloned every visible line, leading to significant allocation pressure and CPU overhead.

📊 **Measured Improvement:** This change eliminates `N` allocations and clones per frame (where `N` is the terminal height). This dramatically reduces memory pressure and CPU usage during rendering, especially in large terminal windows. While environmental limitations (missing dependencies in offline mode) prevented running formal benchmarks, the algorithmic improvement from O(N*W) cloning to O(N) slice collection per frame is a standard and effective optimization for UI rendering loops.

---
*PR created automatically by Jules for task [1938059896722575981](https://jules.google.com/task/1938059896722575981) started by @BlueGeckoJP*